### PR TITLE
NoBlockSkip vs NoBlockTrim

### DIFF
--- a/rtt-target/src/init.rs
+++ b/rtt-target/src/init.rs
@@ -68,7 +68,7 @@ macro_rules! rtt_init_wrappers {
 ///     up: {
 ///         0: { // channel number
 ///             size: 1024 // buffer size in bytes
-///             mode: NoBlockTrim // mode (optional, default: NoBlockTrim, see enum ChannelMode)
+///             mode: NoBlockSkip // mode (optional, default: NoBlockSkip, see enum ChannelMode)
 ///             name: "Terminal" // name (optional, default: no name)
 ///         }
 ///         1: {

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -170,7 +170,7 @@ macro_rules! rprintln {
 /// Initializes RTT with a single up channel and sets it as the print channel for the printing
 /// macros.
 ///
-/// The optional arguments specify the blocking mode (default: `NoBlockTrim`) and size of the buffer
+/// The optional arguments specify the blocking mode (default: `NoBlockSkip`) and size of the buffer
 /// in bytes (default: 1024). See [`rtt_init`] for more details.
 ///
 /// This macro is defined only if the [`set_print_channel`] function is available, i.e. if you have
@@ -197,6 +197,6 @@ macro_rules! rtt_init_print {
     };
 
     () => {
-        $crate::rtt_init_print!(NoBlockTrim, 1024);
+        $crate::rtt_init_print!(NoBlockSkip, 1024);
     };
 }


### PR DESCRIPTION
Update documentation to reflect, that default in the code is 'NoBlockSkip'
(or change the code to 'NoBlockTrim')