### PR TITLE
Fix rprint macro (terminal selection).

### DIFF
--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -124,17 +124,17 @@ pub mod print_impl {
 /// range from 0 to 15.
 #[macro_export]
 macro_rules! rprint {
-    ($s:expr) => {
-        $crate::print_impl::write_str(0, $s);
-    };
-    ($($arg:tt)*) => {
-        $crate::print_impl::write_fmt(0, format_args!($($arg)*));
-    };
     (=> $terminal:expr, $s:expr) => {
         $crate::print_impl::write_str($terminal, $s);
     };
     (=> $terminal:expr, $($arg:tt)*) => {
         $crate::print_impl::write_fmt($terminal, format_args!($($arg)*));
+    };
+    ($s:expr) => {
+        $crate::print_impl::write_str(0, $s);
+    };
+    ($($arg:tt)*) => {
+        $crate::print_impl::write_fmt(0, format_args!($($arg)*));
     };
 }
 


### PR DESCRIPTION
Terminal selection was working in rprintln macro, but not in rprint because of the '($($arg:tt)*)' branch being tried before =>.