### PR TITLE
Update cortex-m to 0.7.1

### DIFF
--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -10,10 +10,10 @@ authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/rtt-target"
 
 [dependencies]
-rtt-target = "0.2.1"
+rtt-target = "0.3.0"
 
 # Platform specific stuff
-cortex-m = { version = "0.6.2", optional = true }
+cortex-m = { version = "0.7.1", optional = true }
 
 [package.metadata.docs.rs]
 features = ["cortex-m"]

--- a/panic-test/Cargo.toml
+++ b/panic-test/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 cortex-m-rt = "0.6.12"
-panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
-rtt-target = "0.2.1"
+panic-rtt-target = { path = "../panic-rtt-target", features = ["cortex-m"] }
+rtt-target = { path = "../rtt-target" }

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/mvirkkunen/rtt-target"
 ufmt-write = "0.1.0"
 
 # Platform specific stuff
-cortex-m = { version = "0.6.2", optional = true }
+cortex-m = { version = "0.7.1", optional = true }
 riscv = { version = "0.6.0", optional = true }
 
 # Dependencies used only for examples


### PR DESCRIPTION
`cortex-m` v0.6.5+ [are forward-compatible](https://github.com/rust-embedded/cortex-m/blob/master/CHANGELOG.md#v065---2021-01-24) with `cortex-m` v0.7.0+, so this should be fine as a point release.

I ran `panic-test` on an `STM32F767ZI` nucleo board to verify that this didn't break anything.