### PR TITLE
Use dev-dependencies for examples. Update crates

### DIFF
--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -10,10 +10,10 @@ authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/rtt-target"
 
 [dependencies]
-rtt-target = "0.2.1"
+rtt-target = "0.3.0"
 
 # Platform specific stuff
-cortex-m = { version = "0.6.2", optional = true }
+cortex-m = { version = "0.7.2", optional = true }
 
 [package.metadata.docs.rs]
 features = ["cortex-m"]

--- a/panic-test/Cargo.toml
+++ b/panic-test/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-cortex-m-rt = "0.6.12"
+cortex-m-rt = "0.6.13"
 panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
-rtt-target = "0.2.1"
+rtt-target = "0.3.0"

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -13,14 +13,14 @@ repository = "https://github.com/mvirkkunen/rtt-target"
 ufmt-write = "0.1.0"
 
 # Platform specific stuff
-cortex-m = { version = "0.6.2", optional = true }
+cortex-m = { version = "0.7.2", optional = true }
 riscv = { version = "0.6.0", optional = true }
 
 # Dependencies used only for examples
 [dev-dependencies]
-ufmt = { version = "0.1.0" }
-cortex-m-rt = { version = "0.6.12" }
-panic-halt = { version = "0.2.0" }
+ufmt = "0.1.0"
+cortex-m-rt = "0.6.13"
+panic-halt = "0.2.0"
 
 [[example]]
 name = "cortex-m-custom"

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -17,24 +17,22 @@ cortex-m = { version = "0.6.2", optional = true }
 riscv = { version = "0.6.0", optional = true }
 
 # Dependencies used only for examples
-ufmt = { version = "0.1.0", optional = true }
-cortex-m-rt = { version = "0.6.12", optional = true }
-panic-halt = { version = "0.2.0", optional = true }
-
-[features]
-examples-cortex-m = ["cortex-m", "cortex-m-rt", "panic-halt", "ufmt"]
+[dev-dependencies]
+ufmt = { version = "0.1.0" }
+cortex-m-rt = { version = "0.6.12" }
+panic-halt = { version = "0.2.0" }
 
 [[example]]
 name = "cortex-m-custom"
-required-features = ["examples-cortex-m"]
+required-features = ["cortex-m"]
 
 [[example]]
 name = "cortex-m-print"
-required-features = ["examples-cortex-m"]
+required-features = ["cortex-m"]
 
 [[example]]
 name = "cortex-m-ufmt"
-required-features = ["examples-cortex-m"]
+required-features = ["cortex-m"]
 
 # This is for the examples
 [profile.release]


### PR DESCRIPTION
Hi,
I think that there could be a reason why features was used instead of dev-dependencies in Cargo.toml if so this should be documented. 